### PR TITLE
Add "Alert" Behavior, remove decorator

### DIFF
--- a/custom_components/vestaboard/__init__.py
+++ b/custom_components/vestaboard/__init__.py
@@ -19,6 +19,7 @@ from .services import async_setup_services
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.IMAGE,
     Platform.SENSOR,
 ]

--- a/custom_components/vestaboard/binary_sensor.py
+++ b/custom_components/vestaboard/binary_sensor.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import homeassistant.util.dt as dt_util
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -11,7 +13,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-import homeassistant.util.dt as dt_util
+
 
 from .const import DOMAIN
 from .coordinator import VestaboardCoordinator

--- a/custom_components/vestaboard/binary_sensor.py
+++ b/custom_components/vestaboard/binary_sensor.py
@@ -37,7 +37,10 @@ class VestaboardAlertActiveEntity(VestaboardEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
-        return self.coordinator.alert_expiration is not None
+        return (
+            self.coordinator.alert_expiration is not None
+            and self.coordinator.alert_expiration > dt_util.now()
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/vestaboard/binary_sensor.py
+++ b/custom_components/vestaboard/binary_sensor.py
@@ -1,0 +1,48 @@
+"""Vestaboard binary sensor entity."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import VestaboardCoordinator
+from .entity import VestaboardEntity
+
+ALERT_MESSAGE_ACTIVE = BinarySensorEntityDescription(
+    key="alert_message_active",
+    name="Alert Message Active",
+    device_class=BinarySensorDeviceClass.RUNNING,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Vestaboard binary sensors using config entry."""
+    coordinator: VestaboardCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([VestaboardAlertActiveEntity(coordinator, entry, ALERT_MESSAGE_ACTIVE)])
+
+
+class VestaboardAlertActiveEntity(VestaboardEntity, BinarySensorEntity):
+    """Vestaboard alert active binary sensor entity."""
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the binary sensor is on."""
+        return self.coordinator.alert_expiration is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        attrs: dict[str, Any] = {}
+        if exp_time := self.coordinator.alert_expiration:
+            attrs["expiration_time"] = exp_time.isoformat()
+        return attrs

--- a/custom_components/vestaboard/binary_sensor.py
+++ b/custom_components/vestaboard/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import VestaboardCoordinator

--- a/custom_components/vestaboard/const.py
+++ b/custom_components/vestaboard/const.py
@@ -10,7 +10,7 @@ ALIGN_RIGHT: Final = "right"
 ALIGNS: Final = [ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]
 
 CONF_ALIGN: Final = "align"
-CONF_DECORATOR: Final = "decorator"
+CONF_DURATION: Final = "duration"
 CONF_ENABLEMENT_TOKEN: Final = "enablement_token"
 CONF_MESSAGE: Final = "message"
 CONF_MODEL: Final = "model"

--- a/custom_components/vestaboard/helpers.py
+++ b/custom_components/vestaboard/helpers.py
@@ -14,7 +14,6 @@ from homeassistant.util.ssl import get_default_context
 from .const import (
     ALIGN_CENTER,
     CONF_ALIGN,
-    CONF_DECORATOR,
     CONF_ENABLEMENT_TOKEN,
     CONF_VALIGN,
     DECORATOR_MUSIC,
@@ -40,19 +39,13 @@ EMOJI_MAP = {
     "⬛": "{70}",
     "■": "{71}",
 }
-BLANK_ROW = [0] * 22
-MUSIC_HEADER = encode_row("{0}Now Playing:{0}", align="center", fill=Color.GREEN)
-
 
 def construct_message(message: str, **kwargs: Any) -> list[list[int]]:
     """Construct a message."""
     message = "".join(EMOJI_MAP.get(char, char) for char in message)
-    if kwargs.get(CONF_DECORATOR) == DECORATOR_MUSIC:
-        return decorate_music(message)
     align = kwargs.get(CONF_ALIGN, ALIGN_CENTER)
     valign = kwargs.get(CONF_VALIGN, VALIGN_MIDDLE)
     return encode_text(message, align=align, valign=valign)
-
 
 def create_client(data: dict[str, Any]) -> LocalClient:
     """Create a Vestaboard local client."""
@@ -93,18 +86,6 @@ def decode(data: list[int] | list[list[int]]) -> None:
     """
     rows = cast(list[list[int]], data if data and isinstance(data[0], list) else [data])
     return "\n".join((f"{''.join(map(symbol, row))}" for row in rows))
-
-
-def decorate_music(message: str) -> list[list[int]]:
-    """Decorate a message with a `Now Playing:` header."""
-    message = encode_text(message, align="center", valign="top")
-    message = [
-        MUSIC_HEADER,
-        *(message if message[-2] != BLANK_ROW else [BLANK_ROW.copy()] + message),
-    ][:6]
-    if message[1][0] == message[1][-1] == 0:
-        message[1][0] = message[1][-1] = Color.GREEN.value
-    return message
 
 
 def symbol(code: int) -> str:

--- a/custom_components/vestaboard/services.py
+++ b/custom_components/vestaboard/services.py
@@ -116,7 +116,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 )
             else:  # This is a persistent message
                 coordinator.persistent_message_rows = rows
-                if not coordinator.alert_expiration:
+                # Only write the message if there is no active alert.
+                # An alert is active if an expiration is set and it's in the future.
+                if not (
+                    coordinator.alert_expiration
+                    and coordinator.alert_expiration > dt_util.now()
+                ):
                     await hass.async_add_executor_job(
                         coordinator.vestaboard.write_message, rows
                     )    

--- a/custom_components/vestaboard/services.py
+++ b/custom_components/vestaboard/services.py
@@ -99,11 +99,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
         for device_id in call.data[CONF_DEVICE_ID]:
             coordinator = async_get_coordinator_by_device_id(hass, device_id)
-            if not coordinator.quiet_hours():
-                coordinator.vestaboard.write_message(rows)
-
-        for device_id in call.data[CONF_DEVICE_ID]:
-            coordinator = async_get_coordinator_by_device_id(hass, device_id)
             if coordinator.quiet_hours():
                 continue
 

--- a/custom_components/vestaboard/services.py
+++ b/custom_components/vestaboard/services.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import voluptuous as vol
 
+from datetime import timedelta
+
 from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant, HomeAssistantError, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv

--- a/custom_components/vestaboard/services.py
+++ b/custom_components/vestaboard/services.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant, HomeAssistantError, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
+import homeassistant.util.dt as dt_util
 
 from .const import (
     ALIGN_CENTER,

--- a/custom_components/vestaboard/services.py
+++ b/custom_components/vestaboard/services.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import voluptuous as vol
-
 from datetime import timedelta
+
+import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant, HomeAssistantError, ServiceCall, callback
@@ -26,7 +26,12 @@ from .const import (
     VALIGNS,
     VBML_URL,
 )
-from .helpers import async_get_coordinator_by_device_id, construct_message
+from .helpers import (
+    async_get_coordinator_by_device_id,
+    construct_message,
+    create_svg,
+    decode,
+)
 
 _character_codes = vol.All(vol.Coerce(int), vol.Range(min=0, max=71))
 _raw_characters = vol.All(cv.ensure_list, [vol.All(cv.ensure_list, [_character_codes])])
@@ -100,7 +105,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         for device_id in call.data[CONF_DEVICE_ID]:
             coordinator = async_get_coordinator_by_device_id(hass, device_id)
             if coordinator.quiet_hours():
-                continue   
+                continue
 
             async def write_and_update_state(message_rows: list[list[int]]):
                 """Write to board and immediately update coordinator."""
@@ -127,7 +132,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                     and coordinator.alert_expiration > dt_util.now()
                 ):
                     await write_and_update_state(rows)
-    
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_MESSAGE,

--- a/custom_components/vestaboard/services.yaml
+++ b/custom_components/vestaboard/services.yaml
@@ -19,6 +19,15 @@ message:
         text:
           multiline: true
       example: This is a message
+    duration:
+      name: Alert Duration
+      description: "Display the message as a temporary alert. The board will revert to its previous persistent message after the duration expires. Duration is in seconds."
+      required: false
+      selector:
+        number:
+          min: 10
+          max: 7200
+          unit_of_measurement: "seconds"
     align:
       name: Align
       description: Horizontal alignment of text. Optional, default=center
@@ -39,14 +48,6 @@ message:
             - "middle"
             - "bottom"
       example: top
-    decorator:
-      name: Decorator
-      description: A decorator to be used with the text. Optional
-      selector:
-        select:
-          options:
-            - "music"
-      example: music
     vbml:
       name: Vestaboard markup language
       description: "Compose a static or dynamic message using Vestaboard markup language. Requires cloud access. See https://docs.vestaboard.com/docs/vbml for more information"


### PR DESCRIPTION
Hey there. We discussed this a while back and I finally got around to making this work. 

It implements "Alerts" through the use of a duration option. The integration will remember the previous persistent message and revert to it after the duration elapses. An alert sent while another is active will just override the old one, then go back to the persistent message. A persistent message sent while an alert is active will not display until the alert duration passes, at which point the new persistent message is displayed. This way automations that update the board, such as with a quote of the day or art, do not cut an alert short, but also don't get ignored.

A new binary_sensor entity is added to show if there is an active alert message. This way automations can look to see if there is already an alert, and wait to send a different alert. The entity has an attribute with the expiration time for the alert, in case you want to do something a bit more advanced. 

Let me know what you think. I used Gemini for most of this, though I reviewed every suggested change line-by-line. It did a pretty good job, and didn't inject a bunch of unrelated changes. I did remove the decorator option to keep the service clean. 

No worries if you don't like it, I'll just fork the repo and make a separate integration with this functionality and make sure users know you did all the work 😂🤣

Thanks!