### PR TITLE
Update services.yaml

### DIFF
--- a/custom_components/vestaboard/services.yaml
+++ b/custom_components/vestaboard/services.yaml
@@ -58,5 +58,5 @@ message:
       selector:
         number:
           min: 10
-          max: 7200
+          max: 43200
           unit_of_measurement: "seconds"


### PR DESCRIPTION
Update duration max

Sorry, I'm bad at pull requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the maximum message duration for the Vestaboard send message service to 12 hours, allowing longer scheduled message displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->