### PR TITLE
Fix DHCP discovery to check all Vestaboard interfaces and add manual ip override

### DIFF
--- a/custom_components/vestaboard/config_flow.py
+++ b/custom_components/vestaboard/config_flow.py
@@ -134,8 +134,13 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
                         data_updates={CONF_HOST: self.host},
                         reason="already_configured",
                     )
-            except Exception:  # pylint: disable=broad-except
-                pass
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.debug(
+                    "Failed to probe entry %s at %s during DHCP discovery: %s",
+                    entry.entry_id,
+                    self.host,
+                    ex,
+                )
 
         return await self.async_step_api_key()
 

--- a/custom_components/vestaboard/config_flow.py
+++ b/custom_components/vestaboard/config_flow.py
@@ -10,12 +10,13 @@ from aiohttp import ClientConnectorError
 import voluptuous as vol
 
 from homeassistant.components import dhcp
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
+    SchemaOptionsFlowHandler,
 )
 from homeassistant.helpers.selector import (
     NumberSelector,
@@ -107,9 +108,9 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(
         config_entry: ConfigEntry,
-    ) -> VestaboardOptionsFlowHandler:
+    ) -> SchemaOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return VestaboardOptionsFlowHandler()
+        return SchemaOptionsFlowHandler(config_entry, OPTIONS_FLOW)
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle dhcp discovery."""
@@ -170,6 +171,34 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Perform reauth upon an API key error."""
         return await self._async_step("reauth_confirm", STEP_API_KEY_SCHEMA, user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle reconfiguration to update the host."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors = {}
+
+        if user_input is not None:
+            self.host = user_input[CONF_HOST]
+            self.api_key = reconfigure_entry.data[CONF_API_KEY]
+            if not (errors := await self.validate_client(
+                {CONF_API_KEY: self.api_key}, write=False
+            )):
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={CONF_HOST: self.host},
+                    reason="reconfigure_successful",
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema({vol.Required(CONF_HOST): str}),
+                {CONF_HOST: reconfigure_entry.data[CONF_HOST]},
+            ),
+            errors=errors,
+        )
 
     async def _async_step(
         self, step_id: str, schema: vol.Schema, user_input: dict[str, Any] | None = None
@@ -263,59 +292,3 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
                             reason="already_configured",
                         )
         return None
-
-
-class VestaboardOptionsFlowHandler(OptionsFlow):
-    """Handle options flow for Vestaboard."""
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Manage the options."""
-        errors: dict[str, str] = {}
-        current_host = self.config_entry.data[CONF_HOST]
-
-        if user_input is not None:
-            new_host = user_input.get(CONF_HOST, current_host)
-            if new_host != current_host:
-                try:
-                    client = await create_client(
-                        self.hass,
-                        {
-                            CONF_HOST: new_host,
-                            CONF_API_KEY: self.config_entry.data[CONF_API_KEY],
-                        },
-                    )
-                    if await client.check_endpoint() == EndpointStatus.UNKNOWN:
-                        errors[CONF_HOST] = "invalid_host"
-                except asyncio.TimeoutError:
-                    errors[CONF_HOST] = "timeout_connect"
-                except ClientConnectorError:
-                    errors[CONF_HOST] = "invalid_host"
-                except Exception as ex:  # pylint: disable=broad-except
-                    _LOGGER.error(ex)
-                    errors["base"] = "unknown"
-
-            if not errors:
-                if new_host != current_host:
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry,
-                        data={**self.config_entry.data, CONF_HOST: new_host},
-                    )
-                return self.async_create_entry(
-                    data={k: v for k, v in user_input.items() if k != CONF_HOST}
-                )
-
-        combined_schema = vol.Schema({vol.Required(CONF_HOST): str}).extend(
-            OPTIONS_SCHEMA.schema
-        )
-        suggested = (
-            user_input
-            if user_input is not None
-            else {CONF_HOST: current_host, **self.config_entry.options}
-        )
-        return self.async_show_form(
-            step_id="init",
-            data_schema=self.add_suggested_values_to_schema(combined_schema, suggested),
-            errors=errors,
-        )

--- a/custom_components/vestaboard/config_flow.py
+++ b/custom_components/vestaboard/config_flow.py
@@ -10,7 +10,7 @@ from aiohttp import ClientConnectorError
 import voluptuous as vol
 
 from homeassistant.components import dhcp
-from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult, section
@@ -106,9 +106,9 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> SchemaOptionsFlowHandler:
+    def async_get_options_flow(config_entry: ConfigEntry) -> VestaboardOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return SchemaOptionsFlowHandler(config_entry, OPTIONS_FLOW)
+        return VestaboardOptionsFlowHandler()
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle dhcp discovery."""
@@ -116,6 +116,27 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
         self.name = discovery_info.hostname
         await self.async_set_unique_id(discovery_info.macaddress)
         self._abort_if_unique_id_configured(updates={CONF_HOST: self.host})
+
+        # The board may have reconnected on a different network interface (e.g.
+        # switching between 2.4 GHz and 5 GHz), giving it a different MAC and
+        # therefore a different unique_id than the one stored on the config entry.
+        # Try each existing entry's API key against the new IP; if it responds,
+        # this is the same board and we can silently update the stored host.
+        for entry in self._async_current_entries():
+            try:
+                client = await create_client(
+                    self.hass,
+                    {CONF_HOST: self.host, CONF_API_KEY: entry.data[CONF_API_KEY]},
+                )
+                if await client.check_endpoint() == EndpointStatus.VALID:
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data_updates={CONF_HOST: self.host},
+                        reason="already_configured",
+                    )
+            except Exception:  # pylint: disable=broad-except
+                pass
+
         return await self.async_step_api_key()
 
     async def async_step_user(
@@ -236,3 +257,59 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
                             reason="already_configured",
                         )
         return None
+
+
+class VestaboardOptionsFlowHandler(OptionsFlow):
+    """Handle options flow for Vestaboard."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        errors: dict[str, str] = {}
+        current_host = self.config_entry.data[CONF_HOST]
+
+        if user_input is not None:
+            new_host = user_input.get(CONF_HOST, current_host)
+            if new_host != current_host:
+                try:
+                    client = await create_client(
+                        self.hass,
+                        {
+                            CONF_HOST: new_host,
+                            CONF_API_KEY: self.config_entry.data[CONF_API_KEY],
+                        },
+                    )
+                    if await client.check_endpoint() == EndpointStatus.UNKNOWN:
+                        errors[CONF_HOST] = "invalid_host"
+                except asyncio.TimeoutError:
+                    errors[CONF_HOST] = "timeout_connect"
+                except ClientConnectorError:
+                    errors[CONF_HOST] = "invalid_host"
+                except Exception as ex:  # pylint: disable=broad-except
+                    _LOGGER.error(ex)
+                    errors["base"] = "unknown"
+
+            if not errors:
+                if new_host != current_host:
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data={**self.config_entry.data, CONF_HOST: new_host},
+                    )
+                return self.async_create_entry(
+                    data={k: v for k, v in user_input.items() if k != CONF_HOST}
+                )
+
+        combined_schema = vol.Schema({vol.Required(CONF_HOST): str}).extend(
+            OPTIONS_SCHEMA.schema
+        )
+        suggested = (
+            user_input
+            if user_input is not None
+            else {CONF_HOST: current_host, **self.config_entry.options}
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(combined_schema, suggested),
+            errors=errors,
+        )

--- a/custom_components/vestaboard/config_flow.py
+++ b/custom_components/vestaboard/config_flow.py
@@ -136,7 +136,14 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
                         data_updates={CONF_HOST: self.host},
                         reason="already_configured",
                     )
-            except Exception as ex:  # pylint: disable=broad-except
+            except asyncio.CancelledError:
+                raise
+            except (
+                ClientConnectorError,
+                asyncio.TimeoutError,
+                OSError,
+                ValueError,
+            ) as ex:
                 _LOGGER.debug(
                     "Failed to probe entry %s at %s during DHCP discovery: %s",
                     entry.entry_id,

--- a/custom_components/vestaboard/config_flow.py
+++ b/custom_components/vestaboard/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
-    SchemaOptionsFlowHandler,
 )
 from homeassistant.helpers.selector import (
     NumberSelector,
@@ -106,7 +105,9 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> VestaboardOptionsFlowHandler:
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> VestaboardOptionsFlowHandler:
         """Get the options flow for this handler."""
         return VestaboardOptionsFlowHandler()
 

--- a/custom_components/vestaboard/config_flow.py
+++ b/custom_components/vestaboard/config_flow.py
@@ -182,9 +182,11 @@ class VestaboardConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.host = user_input[CONF_HOST]
             self.api_key = reconfigure_entry.data[CONF_API_KEY]
-            if not (errors := await self.validate_client(
-                {CONF_API_KEY: self.api_key}, write=False
-            )):
+            if not (
+                errors := await self.validate_client(
+                    {CONF_API_KEY: self.api_key}, write=False
+                )
+            ):
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,
                     data_updates={CONF_HOST: self.host},

--- a/custom_components/vestaboard/manifest.json
+++ b/custom_components/vestaboard/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "dhcp": [
     {
-      "macaddress": "4C93A600*"
+      "macaddress": "4C93A6*"
     }
   ],
   "documentation": "https://github.com/natekspencer/ha-vestaboard",

--- a/custom_components/vestaboard/manifest.json
+++ b/custom_components/vestaboard/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "dhcp": [
     {
-      "macaddress": "4C93A6*"
+      "macaddress": "4C93A60*"
     }
   ],
   "documentation": "https://github.com/natekspencer/ha-vestaboard",

--- a/custom_components/vestaboard/strings.json
+++ b/custom_components/vestaboard/strings.json
@@ -62,6 +62,11 @@
           }
         }
       }
+    },
+    "error": {
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "entity": {

--- a/custom_components/vestaboard/strings.json
+++ b/custom_components/vestaboard/strings.json
@@ -19,6 +19,14 @@
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "enablement_token": "The API key provided is an enablement token and should be used to request a new API key from the board. If you have already performed this step in the past, here or elsewhere, it is strongly encouraged that you use the existing API key. Otherwise, any attempt to read or write with old API keys will fail."
         }
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "Update the IP address or hostname if your Vestaboard has connected on a different network interface and its address has changed."
+        }
       }
     },
     "error": {
@@ -30,20 +38,17 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "options": {
     "step": {
       "init": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
           "model": "Select your Vestaboard color to change the image that is generated",
           "quiet_start": "Quiet hours start time",
           "quiet_end": "Quiet hours end time"
-        },
-        "data_description": {
-          "host": "Update the IP address or hostname if your Vestaboard has connected on a different network interface and its address has changed."
         },
         "sections": {
           "strategy": {
@@ -62,11 +67,6 @@
           }
         }
       }
-    },
-    "error": {
-      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
-      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "entity": {

--- a/custom_components/vestaboard/strings.json
+++ b/custom_components/vestaboard/strings.json
@@ -37,9 +37,13 @@
     "step": {
       "init": {
         "data": {
+          "host": "[%key:common::config_flow::data::host%]",
           "model": "Select your Vestaboard color to change the image that is generated",
           "quiet_start": "Quiet hours start time",
           "quiet_end": "Quiet hours end time"
+        },
+        "data_description": {
+          "host": "Update the IP address or hostname if your Vestaboard has connected on a different network interface and its address has changed."
         },
         "sections": {
           "strategy": {

--- a/custom_components/vestaboard/translations/en.json
+++ b/custom_components/vestaboard/translations/en.json
@@ -19,6 +19,14 @@
           "api_key": "API Key",
           "enablement_token": "The API key provided is an enablement token and should be used to request a new API key from the board. If you have already performed this step in the past, here or elsewhere, it is strongly encouraged that you use the existing API key. Otherwise, any attempt to read or write with old API keys will fail."
         }
+      },
+      "reconfigure": {
+        "data": {
+          "host": "Host"
+        },
+        "data_description": {
+          "host": "Update the IP address or hostname if your Vestaboard has connected on a different network interface and its address has changed."
+        }
       }
     },
     "error": {
@@ -30,20 +38,17 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "reauth_successful": "Re-authentication was successful"
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Re-configuration was successful"
     }
   },
   "options": {
     "step": {
       "init": {
         "data": {
-          "host": "Host",
           "model": "Select your Vestaboard color to change the image that is generated",
           "quiet_start": "Quiet hours start time",
           "quiet_end": "Quiet hours end time"
-        },
-        "data_description": {
-          "host": "Update the IP address or hostname if your Vestaboard has connected on a different network interface and its address has changed."
         },
         "sections": {
           "strategy": {
@@ -62,11 +67,6 @@
           }
         }
       }
-    },
-    "error": {
-      "invalid_host": "Invalid hostname or IP address",
-      "timeout_connect": "Timeout establishing connection",
-      "unknown": "Unexpected error"
     }
   },
   "entity": {

--- a/custom_components/vestaboard/translations/en.json
+++ b/custom_components/vestaboard/translations/en.json
@@ -37,9 +37,13 @@
     "step": {
       "init": {
         "data": {
+          "host": "Host",
           "model": "Select your Vestaboard color to change the image that is generated",
           "quiet_start": "Quiet hours start time",
           "quiet_end": "Quiet hours end time"
+        },
+        "data_description": {
+          "host": "Update the IP address or hostname if your Vestaboard has connected on a different network interface and its address has changed."
         },
         "sections": {
           "strategy": {

--- a/custom_components/vestaboard/translations/en.json
+++ b/custom_components/vestaboard/translations/en.json
@@ -62,6 +62,11 @@
           }
         }
       }
+    },
+    "error": {
+      "invalid_host": "Invalid hostname or IP address",
+      "timeout_connect": "Timeout establishing connection",
+      "unknown": "Unexpected error"
     }
   },
   "entity": {


### PR DESCRIPTION
Today my power went out, and when the Vestaboard reconnected it used a different network interface (different MAC address) and so the reserved IP on my network wasn't assigned. Home Assistant now has the _wrong_ IP address in storage and the only fix is for the integration to be removed and re-added, only to happen again the next time my router/the Vestaboard decides to switch to the other interface again.

That got me digging. The Vestaboard seems to have up to three network interfaces (e.g. 2.4 GHz and 5 GHz Wi-Fi), each with its own MAC address. This caused two problems that left the integration unable to reconnect after a power cycle:

1. DHCP discovery filter was too narrow (manifest.json)

The MAC filter 4C93A600* only matched devices with MAC addresses starting with 4C:93:A6:00:xx:xx. My Vestaboard hardware uses 4C:93:A6:0*, so this broader 4C:93:A6 range (e.g. 4C:93:A6:01:*, 4C:93:A6:02:*), and I suspect HA's DHCP watcher was probably silently ignoring all DHCP traffic from the board. Fixed by broadening the filter to 4C93A6*.

2. DHCP handler only matched by MAC, not by board identity (config_flow.py)

Even with the correct filter, if the board reconnected on a different interface than it used during initial setup, the stored unique ID (the original MAC) wouldn't match the new MAC, and HA would treat it as a new unknown device rather than updating the existing entry. Fixed by adding a fallback in async_step_dhcp: after the MAC-based check fails, we try the stored API key against the new IP. If the board responds, we silently update the host and reload with no user interaction required.

3. Manual host override in the Configure panel (config_flow.py, strings.json, translations/en.json)

DHCP discovery is passive and not guaranteed (missed events, static IPs, HA restarts during a lease). Added a Host field to the integration's Configure options panel so users can manually correct the IP address without deleting and re-adding the integration. The new value is validated against the board before saving.

**Testing:**
Admittedly, mDNS on my network is always wonky, so I was only able to thoroughly test #3. But it does work well! After changing the IP address with the new setting for that which is now exposed, the Vestaboard appeared online.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app reconfigure step allowing users to update a Vestaboard host/IP and apply it to an existing integration.

* **Bug Fixes**
  * Device discovery now matches a broader set of devices; when a discovered device validates, the integration’s host is auto-updated and the integration reloads.

* **Documentation**
  * New user-facing texts for the reconfigure form and a “reconfiguration successful” abort message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->