### PR TITLE
Add model and color attributes to message sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ After this integration is set up, you can configure the color of your Vestaboard
 | Flagship | <img alt="Flagship Black Connected" src="images/flagship-black.png" width="100%"> | <img alt="Flagship White Connected" src="images/flagship-white.png" width="100%"> |
 | Note     |     <img alt="Note Black Connected" src="images/note-black.png" width="70%">      |     <img alt="Note White Connected" src="images/note-white.png" width="70%">      |
 
+## 📊 Entities
+
+Each Vestaboard device exposes the following sensor entities:
+
+### `sensor.<name>_message` - Current board message
+
+Tracks the message currently displayed on the board. Updated every 15 seconds.
+
+| Attribute | Type | Description |
+| --------- | ---- | ----------- |
+| `character_codes` | string | All cell codes as a flat `{N}` sequence, row by row (e.g. `{0}{63}{27}...`). 132 values for Flagship, 45 for Note. |
+| `model` | string | Board model: `flagship` (6×22) or `note` (3×15). |
+| `color` | string | Board color scheme: `black` or `white`. |
+
+These attributes are useful for reading the current board state programmatically — for example, to load it into a composer UI or back it up before sending a temporary message.
+
+---
+
 ## 🎬 Actions
 
 ### `vestaboard.message` - Send a message to one or more Vestaboards

--- a/custom_components/vestaboard/sensor.py
+++ b/custom_components/vestaboard/sensor.py
@@ -66,5 +66,9 @@ class VestaboardSensorEntity(VestaboardEntity, SensorEntity):
         """Return entity specific state attributes."""
         if self.entity_description.key == "message" and (data := self.coordinator.data):
             character_codes = "".join(f"{{{code}}}" for row in data for code in row)
-            return {"character_codes": character_codes}
+            attrs: dict[str, Any] = {"character_codes": character_codes}
+            if (board_model := self.coordinator.model) is not None:
+                attrs["model"] = board_model.model
+                attrs["color"] = board_model.color
+            return attrs
         return None


### PR DESCRIPTION
## Summary

- Adds `model` (`"flagship"` or `"note"`) and `color` (`"black"` or `"white"`) as state attributes on the existing `sensor.<name>_message` entity
- Both values are sourced from the coordinator's `VestaboardModel` (already populated after the first data read) so there is no new I/O
- Adds a new **Entities** section to the README documenting all three `message` sensor attributes (`character_codes`, `model`, `color`)

## Motivation

Without these attributes, a frontend integration (or automation) that wants to load the current board state into a composer UI has no way to know the board's physical model or color scheme — two pieces of information needed to correctly interpret the character code grid and render it accurately.

## Test plan

- [ ] Verify `sensor.<name>_message` attributes in HA Developer Tools show `model` and `color` after the integration updates
- [ ] Confirm `model` resolves correctly for both Flagship (6×22) and Note (3×15) boards
- [ ] Confirm `color` reflects the option set in the integration's configuration

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message sensor entity now includes additional metadata exposing the board's model and color information alongside character codes.

* **Documentation**
  * Added new sensor entity documentation detailing all available attributes (`character_codes`, `model`, `color`), update frequency (every 15 seconds), and model-specific details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->